### PR TITLE
mmngr_buf_drv: fix Oops in close

### DIFF
--- a/mmngr_drv/mmngrbuf/mmngrbuf-module/files/mmngrbuf/drv/mmngr_buf_drv.c
+++ b/mmngr_drv/mmngrbuf/mmngrbuf-module/files/mmngrbuf/drv/mmngr_buf_drv.c
@@ -102,7 +102,7 @@ static int close(struct inode *inode, struct file *file)
 		}
 
 		if (!priv->buf) {
-			if (priv->dma_buf) {
+			if (!IS_ERR_OR_NULL(priv->dma_buf)) {
 				pr_err("%s dma_buf\n", __func__);
 				dma_buf_put(priv->dma_buf);
 			}


### PR DESCRIPTION
In case mm_ioc_import_start fails getting the dma_buf, dma_buf will hold
the error and is not null. Calling dma_buf_put(dma_buf) results in a
crash:
```
 ioctl MMD IMPORT START
 MMI IMPORT_START: Operation not permitted
 close dma_buf

 Unable to handle kernel paging request at virtual address ffffffffffffffff
 Mem abort info:
   Exception class = DABT (current EL), IL = 32 bits
   SET = 0, FnV = 0
   EA = 0, S1PTW = 0
 Data abort info:
   ISV = 0, ISS = 0x00000005
   CM = 0, WnR = 0
 swapper pgtable: 4k pages, 39-bit VAs, pgd = ffffff80087eb000
 [ffffffffffffffff] *pgd=0000000000000000, *pud=0000000000000000
 Internal error: Oops: 96000005 [#1] PREEMPT SMP
 Modules linked in: xt_DSCP nls_cp437 texfat(PO) tntfs(PO) xt_nat bridge stp llc af_packet bcmdhd(O) cfg80211 sd_mod ip6table_nat nf_nat_ipv6 dummy iptable_nat nf_nat_ipv4 nf_nat usb_f_eap u_eap usb_f_ncm u_ether usb_f_iap u_serial libcomposite renesas_usbhs udc_core xhci_plat_hcd xhci_hcd phy_rcar_gen3_usb3 cdc_acm cdc_ncm hid_generic usbhid usb_storage scsi_mod asix ax88179_178a usbnet mii ohci_platform ohci_hcd ehci_platform ehci_hcd xtensa_sound(O) snd_soc_simple_card snd_soc_simple_card_utils snd_soc_mibstd3 snd_soc_rcar ehset mpl3115 snd_soc_core industrialio_triggered_buffer usbcore kfifo_buf industrialio xtensa_hifi(O) ip6t_ipv6header phy_rcar_gen3_usb2 usb_common extcon_core fuse avb_vid(O) avb_alsa(O) xt_mark avb_mgr(O) xt_connmark nf_conntrack_ipv6 nf_defrag_ipv6 ptp_broker(O)
  xt_comment xt_set iptable_mangle xt_HL xt_tcpudp xt_limit vspm_if(O) ip6table_mangle uvcs_drv(O) vsp2(O) vspm(O) mmngrbuf(O) ip_set_bitmap_port ip_set_hash_ip ip_set nfnetlink 8021q nf_conntrack_ipv4 nf_defrag_ipv4 xt_conntrack nf_conntrack libcrc32c sja1105_spi(O) sja1105 mmngr(O) ravb rcar_csi2 ptp mdio_bitbang snd_pcm snd_timer snd soundcore rcar_gen3_thermal thermal_sys pvrsrvkm(O) tw9992 rcar_vin v4l2_fwnode v4l2_common ip6table_filter iptable_filter ip6_tables ip_tables x_tables spi_sh_msiof spidev i2c_dev i2c_rcar configfs ixcf_vnet(O) ixcf_vchar(O) coqoshv(O) rcar_du_drm vsp1 videobuf2_vmalloc videobuf2_dma_contig videobuf2_memops rcar_fcp videobuf2_v4l2 videobuf2_core videodev media rcar_lvds drm_kms_helper fb panel_lvds backlight drm
 CPU: 1 PID: 1252 Comm: UI-Thread Tainted: P           O    4.14.75-ltsi-yocto-standard #7
 Hardware name: PCC ZR3 board based on r8a7795 (DT)
 task: ffffffc54723b280[UI-Thread] task.stack: ffffff801f078000
 PC is at dma_buf_put+0xc/0x28
 LR is at close+0x78/0xb8 [mmngrbuf]
 pc : [<ffffff800838d5c8>] lr : [<ffffff8000a210e0>] pstate: 40000145
 sp : ffffff801f07bdb0
 x29: ffffff801f07bdb0 x28: ffffffc54723b280
 x27: ffffff8008511000 x26: 0000000000000039
 x25: ffffffc565523300 x24: ffffffc567389820
 x23: ffffffc565ad9300 x22: ffffffc560cd0f10
 x21: 0000000000000008 x20: ffffffc560cd0f00
 x19: ffffffc4ec233c80 x18: 000000000000005e
 x17: 0000007fb4f92030 x16: ffffff80081a3fd8
 x15: 0000007fb5741e00 x14: 0000007fb5743c18
 x13: 0000000002000000 x12: ffffff800870d000
 x11: ffffff8008785d5a x10: 0000000000000030
 x9 : 00000000000072bd x8 : 0000000000000000
 x7 : 0000000000000000 x6 : 0000000000000002
 x5 : 0000000000000000 x4 : 0000000000000000
 x3 : ffffffffffffffff x2 : ffffffc54723b280
 x1 : ffffffc54723b280 x0 : fffffffffffffff7
 Process UI-Thread (pid: 1252, stack limit = 0xffffff801f078000)
 dump_backtrace(regs = ffffff801f07bc70 tsk = ffffffc54723b280)
 task: ffffffc54723b280[UI-Thread] task.stack: ffffff801f078000
 Call trace:
 Exception stack(0xffffff801f07bc70 to 0xffffff801f07bdb0)
 Exception stack(0xffffff801f07bc70 to 0xffffff801f07bdb0)
 bc60:                                   fffffffffffffff7 ffffffc54723b280
 bc60:                                   fffffffffffffff7 ffffffc54723b280
 bc80: ffffffc54723b280 ffffffffffffffff 0000000000000000 0000000000000000
 bc80: ffffffc54723b280 ffffffffffffffff 0000000000000000 0000000000000000
 bca0: 0000000000000002 0000000000000000 0000000000000000 00000000000072bd
 bca0: 0000000000000002 0000000000000000 0000000000000000 00000000000072bd
 bcc0: 0000000000000030 ffffff8008785d5a ffffff800870d000 0000000002000000
 bcc0: 0000000000000030 ffffff8008785d5a ffffff800870d000 0000000002000000
 bce0: 0000007fb5743c18 0000007fb5741e00 ffffff80081a3fd8 0000007fb4f92030
 bce0: 0000007fb5743c18 0000007fb5741e00 ffffff80081a3fd8 0000007fb4f92030
 bd00: 000000000000005e ffffffc4ec233c80 ffffffc560cd0f00 0000000000000008
 bd00: 000000000000005e ffffffc4ec233c80 ffffffc560cd0f00 0000000000000008
 bd20: ffffffc560cd0f10 ffffffc565ad9300 ffffffc567389820 ffffffc565523300
 bd20: ffffffc560cd0f10 ffffffc565ad9300 ffffffc567389820 ffffffc565523300
 bd40: 0000000000000039 ffffff8008511000 ffffffc54723b280 ffffff801f07bdb0
 bd40: 0000000000000039 ffffff8008511000 ffffffc54723b280 ffffff801f07bdb0
 bd60: ffffff8000a210e0 ffffff801f07bdb0 ffffff800838d5c8 0000000040000145
 bd60: ffffff8000a210e0 ffffff801f07bdb0 ffffff800838d5c8 0000000040000145
 bd80: ffffffc560cd0f00 ffffff8000a22038 0000007fffffffff 0000000000000001
 bd80: ffffffc560cd0f00 ffffff8000a22038 0000007fffffffff 0000000000000001
 bda0: ffffff801f07bdb0 ffffff800838d5c8
 bda0: ffffff801f07bdb0 ffffff800838d5c8
 [<ffffff800838d5c8>] dma_buf_put+0xc/0x28
 [<ffffff8000a210e0>] close+0x78/0xb8 [mmngrbuf]
 [<ffffff80081a8920>] __fput+0xe0/0x1a4
 [<ffffff80081a8a3c>] ____fput+0xc/0x14
 [<ffffff80080bbffc>] task_work_run+0x88/0xac
 [<ffffff8008088a0c>] do_notify_resume+0xd8/0xe8
```