### PR TITLE
Handle invalid translation

### DIFF
--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
@@ -592,6 +592,7 @@ static int mm_ioc_alloc(struct device *mm_dev,
 {
 	int		ret = 0;
 	struct MM_PARAM	tmp;
+	bool		is_translated = false;
 
 	if (copy_from_user(&tmp, (void __user *)in, sizeof(struct MM_PARAM))) {
 		pr_err("%s EFAULT\n", __func__);
@@ -612,7 +613,9 @@ static int mm_ioc_alloc(struct device *mm_dev,
 	}
 
 #ifdef IPMMU_MMU_SUPPORT
-	out->hard_addr = ipmmu_mmu_phys2virt(out->phy_addr);
+	out->hard_addr = ipmmu_mmu_phys2virt(out->phy_addr, &is_translated);
+	if (!is_translated)
+		return -EFAULT;
 #else
 	out->hard_addr = (unsigned int)out->phy_addr;
 #endif
@@ -693,6 +696,7 @@ static int mm_ioc_alloc_co(struct BM *pb, int __user *in, struct MM_PARAM *out)
 	unsigned long	nbits;
 	unsigned long	start_bit;
 	struct MM_PARAM	tmp;
+	bool		is_translated = false;
 
 	if (copy_from_user(&tmp, in, sizeof(struct MM_PARAM))) {
 		pr_err("%s EFAULT\n", __func__);
@@ -720,7 +724,9 @@ static int mm_ioc_alloc_co(struct BM *pb, int __user *in, struct MM_PARAM *out)
 	out->phy_addr = pb->top_phy_addr + (start_bit << pb->order);
 
 #ifdef IPMMU_MMU_SUPPORT
-	out->hard_addr = ipmmu_mmu_phys2virt(out->phy_addr);
+	out->hard_addr = ipmmu_mmu_phys2virt(out->phy_addr, &is_translated);
+	if (!is_translated)
+		return -EFAULT;
 #else
 	out->hard_addr = (unsigned int)out->phy_addr;
 #endif
@@ -1937,7 +1943,7 @@ static void ipmmu_mmu_deinitialize(void)
 	__handle_registers(&ipmmumm, DO_IOUNMAP);
 }
 
-static unsigned int ipmmu_mmu_phys2virt(phys_addr_t paddr)
+static unsigned int ipmmu_mmu_phys2virt(phys_addr_t paddr, bool *is_translated)
 {
 	unsigned int	vaddr = 0;
 	int		section = 0;
@@ -1949,6 +1955,8 @@ static unsigned int ipmmu_mmu_phys2virt(phys_addr_t paddr)
 		    (paddr < ipmmu_mmu_trans_table[section] + SZ_1G)) {
 			vaddr = section * SZ_1G;
 			vaddr |= paddr & 0x3fffffff;
+			if (is_translated)
+				*is_translated = true;
 		}
 	}
 

--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h
@@ -344,7 +344,7 @@ static void ipmmu_mmu_startup(void);
 static void ipmmu_mmu_cleanup(void);
 static int ipmmu_mmu_initialize(void);
 static void ipmmu_mmu_deinitialize(void);
-static unsigned int ipmmu_mmu_phys2virt(phys_addr_t paddr);
+static unsigned int ipmmu_mmu_phys2virt(phys_addr_t paddr, bool *is_translated);
 static phys_addr_t ipmmu_mmu_virt2phys(unsigned int vaddr);
 static int mm_ipmmu_suspend(struct device *dev);
 static int mm_ipmmu_resume(struct device *dev);


### PR DESCRIPTION
When IPMMU support is enabled and address transformation involves a translation table, the input physical address may not match any section of the transformation table. In such case, the default zero value of the virtual address is returned and propagated to the user. The consequences of this error might be visible only in the userspace and finding the root cause may require some effort. It is proposed to handle translation faults as earlier as possible and return an error to a client.