### PR TITLE
Check result when setting DMA mask and coherent

### DIFF
--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
@@ -1749,17 +1749,25 @@ static int mm_probe(struct platform_device *pdev)
 	if (p == NULL)
 		return -1;
 
-	dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
-
 #ifdef IPMMU_MMU_SUPPORT
 	if (!rcar_gen3_ipmmu) {
 		pr_err("%s MMD ERROR\n", __func__);
 		return -1;
 	}
 
-	dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
+	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
+	if (ret)  {
+		pr_err("MMD mm_init ERROR unable to set DMA mode: %d.\n", ret);
+		return -1;
+	}
 	ipmmu_mmu_startup();
 	ipmmu_mmu_initialize();
+#else
+	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
+	if (ret)  {
+		pr_err("MMD mm_init ERROR unable to set DMA mode: %d.\n", ret);
+		return -1;
+	}
 #endif
 
 	misc_register(&misc);


### PR DESCRIPTION
The `dma_set_mask_and_coherent` does not always perform successfully and it also might fail. Ignoring this error and attempting to use DMA in case of failure will lead to undefined behavior. See for details: Documentation/core-api/dma-api-howto.rst

Also, this patch puts the second call of the function inside the conditional block based on `IPMMU_MMU_SUPPORT` value. This is necessary to avoid a double function call when the `IPMMU_MMU_SUPPORT` is true.