### PR TITLE
Set 32-bit DMA mask for M3N and E3

### DIFF
--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
@@ -1754,8 +1754,10 @@ static int mm_probe(struct platform_device *pdev)
 		pr_err("%s MMD ERROR\n", __func__);
 		return -1;
 	}
-
-	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
+	if (soc_device_match(r8a77965) || soc_device_match(r8a77990))
+		ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
+	else
+		ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
 	if (ret)  {
 		pr_err("MMD mm_init ERROR unable to set DMA mode: %d.\n", ret);
 		return -1;

--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
@@ -1749,17 +1749,25 @@ static int mm_probe(struct platform_device *pdev)
 	if (p == NULL)
 		return -1;
 
-	dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
-
 #ifdef IPMMU_MMU_SUPPORT
 	if (!rcar_gen3_ipmmu) {
 		pr_err("%s MMD ERROR\n", __func__);
 		return -1;
 	}
 
-	dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
+	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(40));
+	if (ret)  {
+		pr_err("MMD mm_init ERROR unable to set DMA mode: %d.\n", ret);
+		return -1;
+	}
 	ipmmu_mmu_startup();
 	ipmmu_mmu_initialize();
+#else
+	ret = dma_set_mask_and_coherent(dev, DMA_BIT_MASK(32));
+	if (ret)  {
+		pr_err("MMD mm_init ERROR unable to set DMA mode: %d.\n", ret);
+		return -1;
+	}
 #endif
 
 	misc_register(&misc);


### PR DESCRIPTION
With the current implementation, the MMNGR sets a 40-bit DMA bitmask (when IPMMU is enabled) regardless of the actual SoC. At the same time, M3N and E3 don't have 40-bit address space. IPMMU MMU supports physical address space in the legacy area. It is proposed to make changes that allow using the correct DMA bitmask for all devices.

This MR is based on #6 one. 