### PR TITLE
Apply fix to cache flush and secured buffer for RZ/V

### DIFF
--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
+++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/drv/mmngr_drv.c
@@ -910,7 +910,7 @@ static long ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	int		ercd;
 	int		ret;
 	struct MM_PARAM	*p = file->private_data;
-	struct MM_CACHE_PARAM *cachep;
+	struct MM_CACHE_PARAM cachep;
 	struct device	*mm_dev;
 
 	mm_dev = mm_drvdata->mm_dev;
@@ -963,14 +963,14 @@ static long ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		}
 		break;
 	case MM_IOC_FLUSH:
-		cachep = (struct MM_CACHE_PARAM *)arg;
-		dma_sync_single_for_device(mm_dev, p->hard_addr + cachep->offset,
-					   cachep->len, DMA_FROM_DEVICE);
+		copy_from_user(&cachep, arg, sizeof(struct MM_CACHE_PARAM));
+		dma_sync_single_for_device(mm_dev, p->hard_addr + cachep.offset,
+					   cachep.len, DMA_FROM_DEVICE);
 		break;
 	case MM_IOC_INVAL:
-		cachep = (struct MM_CACHE_PARAM *)arg;
-		dma_sync_single_for_cpu(mm_dev, p->hard_addr + cachep->offset,
-					cachep->len, DMA_TO_DEVICE);
+		copy_from_user(&cachep, arg, sizeof(struct MM_CACHE_PARAM));
+		dma_sync_single_for_cpu(mm_dev, p->hard_addr + cachep.offset,
+					cachep.len, DMA_TO_DEVICE);
 		break;
 	default:
 		pr_err("%s MMD CMD EFAULT\n", __func__);

--- a/mmngr_drv/mmngrbuf/mmngrbuf-module/files/mmngrbuf/drv/mmngr_buf_drv.c
+++ b/mmngr_drv/mmngrbuf/mmngrbuf-module/files/mmngrbuf/drv/mmngr_buf_drv.c
@@ -307,7 +307,9 @@ static int dmabuf_mmap(struct dma_buf *buf, struct vm_area_struct *vma)
 
 static void *dmabuf_vmap(struct dma_buf *buf)
 {
-	return NULL;
+	struct MM_BUF_PRIVATE *priv = buf->priv;
+
+	return phys_to_virt(priv->hard_addr);
 }
 
 static void dmabuf_vunmap(struct dma_buf *buf, void *vaddr)


### PR DESCRIPTION
In the process of developing DRP-AI Sample applications that use mmngr for RZ/V actual SoC (RZ/V2H, RZ/V2M, RZ/V2MA, RZ/V2L), we encountered a few problems when using mmngr, so we had to make some changes.
1. Supports problem where cache flush is not implemented
2. Supports problem that buffer cannot be secured with mmngr when using a USB camera